### PR TITLE
Fix 'Save' Button in Comparisons Tool

### DIFF
--- a/openbudgets/apps/tools/static/tools/comparisons/comparisons.js
+++ b/openbudgets/apps/tools/static/tools/comparisons/comparisons.js
@@ -17,7 +17,7 @@ define([
 
     var default_state = {
             tool        : window.TOOL.id,
-            author      : window.LOGGEDIN_USER.id,
+            author      : window.LOGGEDIN_USER.uuid,
             title       : '',
             description : '',
             author_model: new resources.User(window.LOGGEDIN_USER),

--- a/openbudgets/apps/tools/static/tools/comparisons/controllers/AppState.js
+++ b/openbudgets/apps/tools/static/tools/comparisons/controllers/AppState.js
@@ -51,7 +51,7 @@ define(['uijet_dir/uijet'], function (uijet) {
         },
         saveState       : function () {
             var state = uijet.Resource('ToolState'),
-                user_id = uijet.Resource('LoggedinUser').get('id');
+                user_id = uijet.Resource('LoggedinUser').get('uuid');
             if ( user_id ) {
                 if ( state.get('author') === user_id ) {
                     return this._saveState(state);

--- a/openbudgets/apps/tools/static/tools/comparisons/resources/commons.js
+++ b/openbudgets/apps/tools/static/tools/comparisons/resources/commons.js
@@ -43,6 +43,7 @@ define([
          * User (Account) Model
          */
         User = uijet.Model({
+			idAttribute: 'uuid',
             name    : function () {
                 var first = this.get('first_name'),
                     last = this.get('last_name');

--- a/openbudgets/apps/tools/static/tools/comparisons/resources/commons.js
+++ b/openbudgets/apps/tools/static/tools/comparisons/resources/commons.js
@@ -43,7 +43,7 @@ define([
          * User (Account) Model
          */
         User = uijet.Model({
-			idAttribute: 'uuid',
+            idAttribute: 'uuid',
             name    : function () {
                 var first = this.get('first_name'),
                     last = this.get('last_name');

--- a/openbudgets/apps/tools/static/tools/comparisons/ui/chart-container.js
+++ b/openbudgets/apps/tools/static/tools/comparisons/ui/chart-container.js
@@ -67,9 +67,9 @@ define([
             dont_wake   : function () {
                 return ! uijet.Resource('ToolState').has('id');
             },
-			app_events: {
-				chart_saved: 'wake'
-			}
+            app_events: {
+                chart_saved: 'wake'
+            }
         }
     }, {
         type    : 'Button',
@@ -78,9 +78,9 @@ define([
             dont_wake   : function () {
                 return ! uijet.Resource('ToolState').has('id');
             },
-			app_events: {
-				chart_saved: 'wake'
-			}
+            app_events: {
+                chart_saved: 'wake'
+            }
         }
     }, {
         factory : 'ChartMenuButton',
@@ -97,7 +97,7 @@ define([
             app_events  : {
                 state_cleared       : enableMenuButton,
                 state_delete_failed : enableMenuButton,
-				chart_saved: 'wake'
+                chart_saved: 'wake'
             }
         }
     }, {
@@ -107,7 +107,7 @@ define([
             app_events  : {
                 state_saved         : enableMenuButton,
                 state_save_failed   : enableMenuButton,
-				chart_saved: 'wake'
+                chart_saved: 'wake'
             }
         }
     }, {    
@@ -123,7 +123,7 @@ define([
                     }
                     else {
                         this.disable().spin();
-						uijet.publish('chart_saved');
+                        uijet.publish('chart_saved');
                     }
                 }
             },

--- a/openbudgets/apps/tools/static/tools/comparisons/ui/chart-container.js
+++ b/openbudgets/apps/tools/static/tools/comparisons/ui/chart-container.js
@@ -66,7 +66,10 @@ define([
             element     : '#viz_export',
             dont_wake   : function () {
                 return ! uijet.Resource('ToolState').has('id');
-            }
+            },
+			app_events: {
+				chart_saved: 'wake'
+			}
         }
     }, {
         type    : 'Button',
@@ -74,7 +77,10 @@ define([
             element     : '#viz_publish',
             dont_wake   : function () {
                 return ! uijet.Resource('ToolState').has('id');
-            }
+            },
+			app_events: {
+				chart_saved: 'wake'
+			}
         }
     }, {
         factory : 'ChartMenuButton',
@@ -82,7 +88,7 @@ define([
             element     : '#viz_delete',
             dont_wake   : function () {
                 var state = uijet.Resource('ToolState');
-                if ( uijet.Resource('LoggedinUser').get('id') === state.get('author') ) {
+                if ( uijet.Resource('LoggedinUser').get('uuid') === state.get('author') ) {
                     return ! state.has('id');
                 }
 
@@ -90,7 +96,8 @@ define([
             },
             app_events  : {
                 state_cleared       : enableMenuButton,
-                state_delete_failed : enableMenuButton
+                state_delete_failed : enableMenuButton,
+				chart_saved: 'wake'
             }
         }
     }, {
@@ -99,7 +106,8 @@ define([
             element     : '#viz_duplicate',
             app_events  : {
                 state_saved         : enableMenuButton,
-                state_save_failed   : enableMenuButton
+                state_save_failed   : enableMenuButton,
+				chart_saved: 'wake'
             }
         }
     }, {    
@@ -109,12 +117,13 @@ define([
             dont_wake   : false,
             signals : {
                 pre_click   : function () {
-                    if ( ! uijet.Resource('LoggedinUser').has('id') ) {
+                    if ( ! uijet.Resource('LoggedinUser').has('uuid') ) {
                         uijet.publish('login');
                         return false;
                     }
                     else {
                         this.disable().spin();
+						uijet.publish('chart_saved');
                     }
                 }
             },


### PR DESCRIPTION
Fixed the 'Save' button behavior in the comparison's chart widget.
Button can be clicked when logged in, other buttons will appear when appropriate.
